### PR TITLE
Fix hangin seek requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,13 @@ module.exports = class BlobReadStream extends Readable {
       return
     }
 
-    const [start, end] = await Promise.all([this._setStart(), this._prefetch ? this._setEnd() : Promise.resolve(0)])
+    let start, end
+    try {
+      [start, end] = await Promise.all([this._setStart(), this._prefetch ? this._setEnd() : Promise.resolve(0)])
+    } catch (err) {
+      cb(err)
+      return
+    }
     if (start < this.id.blockOffset || start >= this._blockEnd) {
       this._length = 0
       this.push(null)

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = class BlobReadStream extends Readable {
   }
 
   async _setEnd () {
-    if (this._length >= this.id.byteLength || this._length === -1) {
+    if (this._length >= this.id.byteLength || this._length === -1 || this._start + this._length >= this.id.byteLength) {
       return this.id.blockOffset + this.id.blockLength
     }
 

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports = class BlobReadStream extends Readable {
   }
 
   async _setEnd () {
-    if (this._length >= this.id.byteLength || this._length === -1 || this._start + this._length >= this.id.byteLength) {
+    if (this._start + this._length >= this.id.byteLength || this._length === -1) {
       return this.id.blockOffset + this.id.blockLength
     }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "brittle": "^3.7.0",
     "hypercore": "^10.38.1",
     "standard": "^17.1.2",
-    "test-tmp": "^1.3.1"
+    "test-tmp": "^1.3.1",
+    "uncaughts": "^1.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "brittle": "^3.7.0",
     "hypercore": "^10.38.1",
     "standard": "^17.1.2",
-    "test-tmp": "^1.3.1",
-    "uncaughts": "^1.1.3"
+    "test-tmp": "^1.3.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,7 +3,6 @@ const Hypercore = require('hypercore')
 const tmp = require('test-tmp')
 const b4a = require('b4a')
 const ByteStream = require('./')
-const uncaughts = require('uncaughts')
 
 test('basic', async function (t) {
   const { id, core } = await create(t, ['a', 'b', 'c', 'd', 'e'])
@@ -138,11 +137,6 @@ test('destroying while seeking in open isnt uncaught', async (t) => {
   await clone.ready()
   t.teardown(() => clone.close())
 
-  const checkUncaught = (err) => {
-    t.fail('got uncaught', err.code)
-  }
-  uncaughts.on(checkUncaught)
-
   const stream = new ByteStream(clone, id, { start: 3 })
   stream.resume()
 
@@ -151,7 +145,6 @@ test('destroying while seeking in open isnt uncaught', async (t) => {
   stream.destroy()
 
   t.ok(stream.core.closed, 'core was closed')
-  uncaughts.off(checkUncaught)
 })
 
 test('prefetch seeks to correct bytes position', async (t) => {

--- a/test.js
+++ b/test.js
@@ -154,7 +154,7 @@ test('destroying while seeking in open isnt uncaught', async (t) => {
   uncaughts.off(checkUncaught)
 })
 
-test('prefetch request correct range', async (t) => {
+test('prefetch seeks to correct bytes position', async (t) => {
   const { id, core } = await create(t, ['a', 'b', 'c', 'd', 'e'])
 
   const dir = await t.tmp()

--- a/test.js
+++ b/test.js
@@ -154,6 +154,25 @@ test('destroying while seeking in open isnt uncaught', async (t) => {
   uncaughts.off(checkUncaught)
 })
 
+test('prefetch request correct range', async (t) => {
+  const { id, core } = await create(t, ['a', 'b', 'c', 'd', 'e'])
+
+  const dir = await t.tmp()
+  const clone = new Hypercore(dir, core.key)
+  await clone.ready()
+  t.teardown(() => clone.close())
+
+  replicate(core, clone, t)
+
+  const stream = new ByteStream(clone, id, { start: 3, length: 4 })
+  stream.resume()
+
+  await new Promise((resolve) => setImmediate(resolve)) // Allow the seek to register
+
+  t.absent(clone.activeRequests.some((r) => r.context.seeker.bytes > id.byteLength + id.byteOffset), 'no seek request > id\'s byte offset & length')
+  stream.destroy()
+})
+
 async function create (t, blocks, repeat = 1) {
   const dir = await tmp(t)
   const core = new Hypercore(dir)
@@ -184,4 +203,32 @@ async function collect (stream) {
   const chunks = []
   for await (const data of stream) chunks.push(b4a.toString(data))
   return chunks
+}
+
+function replicate (a, b, t, opts = {}) {
+  const s1 = a.replicate(true, { keepAlive: false, ...opts })
+  const s2 = b.replicate(false, { keepAlive: false, ...opts })
+
+  const closed1 = new Promise((resolve) => s1.once('close', resolve))
+  const closed2 = new Promise((resolve) => s2.once('close', resolve))
+
+  s1.on('error', (err) => {
+    t.comment(`replication stream error (initiator): ${err}`)
+  })
+  s2.on('error', (err) => {
+    t.comment(`replication stream error (responder): ${err}`)
+  })
+
+  if (opts.teardown !== false) {
+    t.teardown(async function () {
+      s1.destroy()
+      s2.destroy()
+      await closed1
+      await closed2
+    })
+  }
+
+  s1.pipe(s2).pipe(s1)
+
+  return [s1, s2]
 }

--- a/test.js
+++ b/test.js
@@ -173,6 +173,33 @@ test('prefetch seeks to correct bytes position', async (t) => {
   stream.destroy()
 })
 
+test('prefetch range includes all blocks needed', async (t) => {
+  t.plan(2)
+  const { id, core } = await create(t, ['a', 'b', 'c', 'd', 'e'])
+
+  const dir = await t.tmp()
+  const clone = new Hypercore(dir, core.key)
+  await clone.ready()
+  t.teardown(() => clone.close())
+
+  replicate(core, clone, t)
+
+  const stream = new ByteStream(clone, id, { start: 1, length: 3 })
+  stream.resume()
+  const range = { start: -1, end: -1 }
+  const all = []
+  stream.on('open', () => {
+    const rangeReqs = clone.activeRequests.find((r) => 'ranges' in r.context)
+    t.ok(rangeReqs, 'found range request in open')
+    range.start = rangeReqs.context.start
+    range.end = rangeReqs.context.end
+  }).on('data', (data) => {
+    all.push(data)
+  }).on('close', () => {
+    t.is(range.end - range.start, all.length, 'range length = stream length')
+  })
+})
+
 async function create (t, blocks, repeat = 1) {
   const dir = await tmp(t)
   const core = new Hypercore(dir)

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ const Hypercore = require('hypercore')
 const tmp = require('test-tmp')
 const b4a = require('b4a')
 const ByteStream = require('./')
+const uncaughts = require('uncaughts')
 
 test('basic', async function (t) {
   const { id, core } = await create(t, ['a', 'b', 'c', 'd', 'e'])
@@ -125,6 +126,32 @@ test('one', async function (t) {
     const result = await collect(b)
     t.alike(result, ['llo', 'w'])
   }
+})
+
+test('destroying while seeking in open isnt uncaught', async (t) => {
+  t.plan(1)
+  const { id, core } = await create(t, ['a', 'b', 'c', 'd', 'e'])
+
+  // Clone with no info (by design)
+  const dir = await t.tmp()
+  const clone = new Hypercore(dir, core.key)
+  await clone.ready()
+  t.teardown(() => clone.close())
+
+  const checkUncaught = (err) => {
+    t.fail('got uncaught', err.code)
+  }
+  uncaughts.on(checkUncaught)
+
+  const stream = new ByteStream(clone, id, { start: 3 })
+  stream.resume()
+
+  await new Promise((resolve) => setImmediate(resolve)) // Allow the seek to register
+
+  stream.destroy()
+
+  t.ok(stream.core.closed, 'core was closed')
+  uncaughts.off(checkUncaught)
 })
 
 async function create (t, blocks, repeat = 1) {

--- a/test.js
+++ b/test.js
@@ -128,7 +128,6 @@ test('one', async function (t) {
 })
 
 test('destroying while seeking in open isnt uncaught', async (t) => {
-  t.plan(1)
   const { id, core } = await create(t, ['a', 'b', 'c', 'd', 'e'])
 
   // Clone with no info (by design)
@@ -138,13 +137,17 @@ test('destroying while seeking in open isnt uncaught', async (t) => {
   t.teardown(() => clone.close())
 
   const stream = new ByteStream(clone, id, { start: 3 })
+  let opened = false
+  stream.on('open', () => {
+    opened = true
+  })
   stream.resume()
 
   await new Promise((resolve) => setImmediate(resolve)) // Allow the seek to register
 
   stream.destroy()
 
-  t.ok(stream.core.closed, 'core was closed')
+  t.absent(opened, 'stream didnt open')
 })
 
 test('prefetch seeks to correct bytes position', async (t) => {


### PR DESCRIPTION
This fix prevents throwing an uncaught `REQUEST_CANCELLED` when destroying a stream that can't fulfill the seek requests for setting up the stream.

Also fixes bug where a combination of custom `start` & `length` options could request more blocks than necessary for prefetch.

Co-written with AI